### PR TITLE
DB creation scripts revision

### DIFF
--- a/cnf/env/dev.env.json
+++ b/cnf/env/dev.env.json
@@ -26,7 +26,7 @@
          "postgres_db_user_pw" : "Q3gZ6IWEdwd8",
          "postgres_db_useradmin_pw" : "eFGml0rjzgUa",
          "postgres_db_port" : "15432",
-         "postgres_db_host" : "127.0.0.1",
+         "postgres_db_host" : "172.31.0.1",
          "app_user_pwd" : "zpGcWMSmD2WQ",
          "postgres_usr_pw" : "3VGMcfdVxhVE",
          "root_pwd" : "c7RN8xzWpW9h",
@@ -52,7 +52,7 @@
       },
       "redis" : {
          "port" : "6379",
-         "server" : "127.0.0.1"
+         "server" : "172.31.0.1"
       },
       "app" : {
          "nginx_port" : "78",
@@ -62,7 +62,7 @@
          "https_port" : "441",
          "ws_protocol" : "ws",
          "inactivity_timeout" : "60",
-         "web_host" : "host-name",
+         "web_host" : "172.31.0.1",
          "port" : "8078",
          "mojo_morbo_port" : "3001",
          "mojo_hypnotoad_port" : "8078"

--- a/cnf/env/prd.env.json
+++ b/cnf/env/prd.env.json
@@ -2,7 +2,7 @@
    "env" : {
       "redis" : {
          "port" : "6379",
-         "server" : "127.0.0.1"
+         "server" : "172.31.0.1"
       },
       "db" : {
          "postgres_db_name" : "prd_qto",
@@ -11,9 +11,9 @@
          "root_pwd" : "c7RN8xzWpW9h",
          "postgres_db_user" : "usrprdqtoapp",
          "postgres_usr_pw" : "gHDEmUQXY2Os",
-         "project_databases" : "prd_csitea , prd_ysg",
+         "project_databases" : "prd_qto",
          "AdminEmail" : "3psrgkg4vtpZ",
-         "postgres_db_host" : "127.0.0.1",
+         "postgres_db_host" : "172.31.0.1",
          "app_user_pwd" : "pnqYP5Z7P1Mb",
          "postgres_db_useradmin" : "usrprdqtoadmin",
          "postgres_os_usr_pw" : "6WS6J2GqduoQ",
@@ -49,7 +49,7 @@
          "mojo_morbo_port" : "3003",
          "postgres_db_name" : "prd_qto",
          "https_port" : "443",
-         "web_host" : "host-name"
+         "web_host" : "172.31.0.1"
       },
       "log" : {
          "LogDir" : "$ProductInstanceDir/dat/log",

--- a/cnf/env/tst.env.json
+++ b/cnf/env/tst.env.json
@@ -22,7 +22,7 @@
          "ws_protocol" : "ws",
          "num_of_workers" : "5",
          "ht_protocol" : "http",
-         "web_host" : "host-name",
+         "web_host" : "172.31.0.1",
          "https_port" : "442",
          "mojo_morbo_port" : "3002",
          "port" : "8082",
@@ -56,8 +56,8 @@
          "postgres_usr_pw" : "N4r9NBDOh5zp",
          "app_user_pwd" : "zcXbCOZbC5lT",
          "postgres_db_useradmin" : "usrtstqtoadmin",
-         "project_databases" : "tst_qto, tst_vaultit, tst_jor",
-         "postgres_db_host" : "127.0.0.1",
+         "project_databases" : "tst_qto",
+         "postgres_db_host" : "172.31.0.1",
          "root_pwd" : "c7RN8xzWpW9h",
          "postgres_db_user" : "usrtstqtoapp",
          "AdminEmail" : "Y7d8Zwz0LffB",
@@ -66,7 +66,7 @@
       },
       "redis" : {
          "port" : "6379",
-         "server" : "127.0.0.1"
+         "server" : "172.31.0.1"
       }
    },
    "multi_lines_comment" : "to indicate new line use \\n, to indicate 3 spaces \\t"

--- a/src/bash/deployer/check-install-redis.func.sh
+++ b/src/bash/deployer/check-install-redis.func.sh
@@ -28,7 +28,6 @@ do_check_install_redis(){
       # restart to apply the changes 
 		sudo systemctl restart redis
       sudo systemctl restart redis.service
-		sudo systemctl status redis
 
       # check that redis is running
       sudo ps -ef | grep -v grep | grep -i redis

--- a/src/bash/deployer/check-install-redis.func.sh
+++ b/src/bash/deployer/check-install-redis.func.sh
@@ -18,8 +18,8 @@ do_check_install_redis(){
       echo "bind $my_ip"| sudo tee -a /etc/redis/redis.conf
       echo 'supervised systemd' | sudo tee -a /etc/redis/redis.conf
 
-      # uncomment out the ip6 bind directive, it brakes the redis
-      perl -pi -e 's/bind 127.0.0.1 ::1/#bind 127.0.0.1 ::1/g' /etc/redis/redis.conf
+      # uncomment out the ip6 bind directive, it breaks the redis
+      sudo perl -pi -e 's/bind 127.0.0.1 ::1/#bind 127.0.0.1 ::1/ig' /etc/redis/redis.conf
 
 
 

--- a/src/bash/deployer/provision-ssh-keys.func.sh
+++ b/src/bash/deployer/provision-ssh-keys.func.sh
@@ -10,7 +10,7 @@ do_provision_ssh_keys(){
    test -f $prv_key_fpath || {
    expect <<- EOF_EXPECT
       set timeout -1
-      spawn ssh-keygen -t rsa -b 4096 -C $AdminEmail -f $prv_key_fpath
+      spawn ssh-keygen -t rsa -b 4096 -C $AdminEmail -f $prv_key_fpath -N ''
       expect "Enter passphrase (empty for no passphrase): "
       send -- "\r"
 		expect "Enter same passphrase again: "
@@ -30,7 +30,7 @@ EOF_EXPECT
       $jwt_public_key_file
 EOF_USING
       
-      test -f $jwt_private_key_file || ssh-keygen -t rsa -b 4096 -m PEM -f $jwt_private_key_file
+      test -f $jwt_private_key_file || ssh-keygen -t rsa -b 4096 -m PEM -f $jwt_private_key_file -N ''
       test -f $jwt_public_key_file && rm -v $jwt_public_key_file
       openssl rsa -in $jwt_private_key_file -pubout -outform PEM -out $jwt_public_key_file
    done;

--- a/src/bash/deployer/qto/cnf/bin/perl-modules.lst
+++ b/src/bash/deployer/qto/cnf/bin/perl-modules.lst
@@ -17,7 +17,6 @@
       File::Copy
       File::Find
       File::Path
-      Excel::Writer::XLSX
       Spreadsheet::ParseExcel
       Spreadsheet::XLSX
       Spreadsheet::ParseExcel::FmtJapan

--- a/src/bash/deployer/qto/cnf/bin/perl-modules.lst
+++ b/src/bash/deployer/qto/cnf/bin/perl-modules.lst
@@ -1,16 +1,18 @@
-      JSON  
+      JSON	  
+      JSON::Parse
       Data::Printer
       Carp::Always
       IO::CaptureOutput
       Net::DNS
       Net::Domain::TLD
       Email::Valid
-      Test::Most 
-      Data::Printer 
       FindBin
-      JSON::Parse 
       IPC::System::Simple 
-      Mojolicious 
+      Mojolicious	  
+      Mojolicious::Plugin::BasicAuthPlus
+      Mojolicious::Plugin::StaticCache
+      Mojolicious::Plugin::RenderFile
+      Mojolicious::Plugin::Authentication
       IO::Socket::SSL  
       URL::Encode
       ExtUtils::Installed
@@ -22,36 +24,25 @@
       Spreadsheet::ParseExcel::FmtJapan
       Text::CSV_XS
       Module::Build::Tiny
-      URL::Encode
-      Data::Printer
       File::Copy::Recursive
-      Spreadsheet::ParseExcel
-      Spreadsheet::XLSX
-      JSON
-      Text::CSV_XS
       Test::Trap
       Test::More
-      Test::Most
+      Test::Most	  
+      Test::Mojo
       DBD::Pg
       Tie::Hash::DBD
       Scalar::Util::Numeric
       IPC::System::Simple
       Time::HiRes
-      Mojolicious::Plugin::BasicAuthPlus
-      Mojolicious::Plugin::StaticCache
-      Mojolicious::Plugin::RenderFile
-      Mojolicious::Plugin::Authentication
       Mojo::JWT
       Mojo::Pg
       Mojo::Phantom 
-      Test::Mojo
       Authen::Passphrase::BlowfishCrypt
       Selenium::Remote::Driver
       Selenium::Chrome
       Term::ReadKey
       Term::Prompt
       DBIx::ProcedureCall
-      JSON::Parse
       Storable
       Redis
       Crypt::OpenSSL::RSA

--- a/src/bash/qto/funcs/run-qto-db-ddl.func.sh
+++ b/src/bash/qto/funcs/run-qto-db-ddl.func.sh
@@ -41,6 +41,7 @@ doRunQtoDbDdl(){
    PGPASSWORD="${postgres_db_useradmin_pw:-}" psql -q -t -X -w -U "${postgres_db_useradmin:-}" \
       -h $postgres_db_host -p $postgres_db_port -d postgres -v ON_ERROR_STOP=1 -c \
       "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $postgres_db_user;
+	  GRANT CONNECT ON DATABASE $postgres_db_name TO $postgres_db_user;
 	  GRANT SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO $postgres_db_user;
       GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO $postgres_db_user;"
 

--- a/src/bash/qto/funcs/run-qto-db-ddl.func.sh
+++ b/src/bash/qto/funcs/run-qto-db-ddl.func.sh
@@ -10,7 +10,7 @@ doRunQtoDbDdl(){
    # 00 create the db
    tmp_log_file="$tmp_dir/.$$.log"
 	pgsql_scripts_dir="$PRODUCT_INSTANCE_DIR/src/sql/pgsql/qto"
-   sql_script="$pgsql_scripts_dir/""00.create-db.pgsql"
+   sql_script="$pgsql_scripts_dir/00.create-db.pgsql"
 
    PGPASSWORD="${postgres_db_useradmin_pw:-}" psql -v -q -t -X -w -U "${postgres_db_useradmin:-}" \
       -h $postgres_db_host -p $postgres_db_port -v ON_ERROR_STOP=1 \
@@ -40,7 +40,8 @@ doRunQtoDbDdl(){
    } 
    PGPASSWORD="${postgres_db_useradmin_pw:-}" psql -q -t -X -w -U "${postgres_db_useradmin:-}" \
       -h $postgres_db_host -p $postgres_db_port -d postgres -v ON_ERROR_STOP=1 -c \
-      "GRANT SELECT ON ALL TABLES IN SCHEMA public TO $postgres_db_user; 
-      GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO $postgres_db_user"
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $postgres_db_user;
+	  GRANT SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO $postgres_db_user;
+      GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO $postgres_db_user;"
 
 }

--- a/src/perl/qto/script/qto_preq_checker.pl
+++ b/src/perl/qto/script/qto_preq_checker.pl
@@ -50,24 +50,17 @@ sub doCheckRequiredModules {
    ExtUtils::Installed
    Carp::Always
    Data::Printer
-   File::Copy
+   File::Copy   
+   File::Copy::Recursive
    File::Find
    File::Path
-   Excel::Writer::XLSX
    Spreadsheet::ParseExcel
    Spreadsheet::XLSX
    Spreadsheet::ParseExcel::FmtJapan
    Text::CSV_XS
    Module::Build::Tiny
-   Carp::Always
-   URL::Encode
-   Carp::Always
-   Data::Printer
-   File::Copy::Recursive
-   Spreadsheet::ParseExcel
-   Spreadsheet::XLSX
-   JSON
-   Text::CSV_XS
+   JSON   
+   JSON::Parse
    Test::Trap
    Test::More
    Test::Most
@@ -75,27 +68,26 @@ sub doCheckRequiredModules {
    Tie::Hash::DBD
    Scalar::Util::Numeric
    IPC::System::Simple
-   Mojo::Pg
    Selenium::Remote::Driver
    Selenium::Chrome
    Mojolicious::Plugin::BasicAuthPlus
    Mojolicious::Plugin::StaticCache
-   Mojolicious::Plugin::RenderFile
-   Time::HiRes
+   Mojolicious::Plugin::RenderFile   
    Mojolicious::Plugin::Authentication
    Mojo::JWT
-   Mojo::Pg
+   Mojo::Pg   
+   Time::HiRes
    Authen::Passphrase::BlowfishCrypt
-   Net::Google::DataAPI::Auth::OAuth2
-   Net::Google::Spreadsheets::V4
-   Net::Google::Spreadsheets;
    Net::Google::DataAPI::Auth::OAuth2
    Net::Google::Spreadsheets::V4
    Net::Google::Spreadsheets
    Term::ReadKey
    Term::Prompt
    DBIx::ProcedureCall
-   JSON::Parse
+   Storable
+   Redis
+   Crypt::OpenSSL::RSA
+   Gravatar::URL
   );
 
   for (@modules) {

--- a/src/sql/pgsql/qto/00.create-db.pgsql
+++ b/src/sql/pgsql/qto/00.create-db.pgsql
@@ -1,11 +1,31 @@
-SELECT 'OBS !!! drop the db if it already exists' ; 
+-- \echo 'DROP the DB if it already exists'
 DROP DATABASE IF EXISTS :postgres_db_name ;
 
-SELECT ' CREATE THE DB :postgres_db_name ' ; 
-CREATE DATABASE :postgres_db_name ;
+-- \echo 'CREATE the DB :postgres_db_name '
+CREATE DATABASE :postgres_db_name
+       TEMPLATE=template1
+       ENCODING='UTF-8'
+       TABLESPACE=pg_default
+       LC_COLLATE='C'
+       LC_CTYPE='C'
+       CONNECTION LIMIT=-1;
 
-SELECT 'and check that the :postgres_db_name db exists:' ; 
-SELECT datname , datcollate FROM pg_database WHERE datname=:'postgres_db_name' ; 
+-- \echo 'and check that the :postgres_db_name DB exists:'
+SELECT datname, datcollate
+	FROM pg_database
+	WHERE datname=:'postgres_db_name' ;
+	
+COMMENT ON DATABASE :postgres_db_name
+	IS 'Database for QTO' ;
 
-SELECT 'SET THE DEFAULT SEARCH LANGUAGE TO BE ENGLISH' ; 
-ALTER DATABASE :postgres_db_name SET default_text_search_config = 'pg_catalog.english' ; 
+-- \echo 'REVOKE all rights on the newly created DB'
+REVOKE ALL
+	ON DATABASE :postgres_db_name
+	FROM public;
+
+-- \echo 'SET the DEFAULT search language to English'
+ALTER DATABASE :postgres_db_name
+	SET default_text_search_config='pg_catalog.english' ;
+
+
+

--- a/src/sql/pgsql/qto/00.create-db.pgsql
+++ b/src/sql/pgsql/qto/00.create-db.pgsql
@@ -3,8 +3,6 @@ DROP DATABASE IF EXISTS :postgres_db_name ;
 
 -- \echo 'CREATE the DB :postgres_db_name '
 CREATE DATABASE :postgres_db_name
-       LC_COLLATE='C'
-       LC_CTYPE='C'
        CONNECTION LIMIT=-1;
 
 -- \echo 'and check that the :postgres_db_name DB exists:'

--- a/src/sql/pgsql/qto/00.create-db.pgsql
+++ b/src/sql/pgsql/qto/00.create-db.pgsql
@@ -3,9 +3,6 @@ DROP DATABASE IF EXISTS :postgres_db_name ;
 
 -- \echo 'CREATE the DB :postgres_db_name '
 CREATE DATABASE :postgres_db_name
-       TEMPLATE=template1
-       ENCODING='UTF-8'
-       TABLESPACE=pg_default
        LC_COLLATE='C'
        LC_CTYPE='C'
        CONNECTION LIMIT=-1;

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -17,48 +17,55 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN
 	RAISE NOTICE 'User "%" already exists, re-creating it', current_setting('myvars.postgres_db_user', true)::text;
 	EXECUTE format( '
-            GRANT SELECT, INSERT, UPDATE, DELETE
-				ON ALL TABLES
-				IN SCHEMA public
-				TO %I '
+            GRANT CONNECT
+				ON DATABASE %I
+				TO %I ;'
+			, current_setting('myvars.postgres_db_name', true)::text 
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-			ALTER DEFAULT PRIVILEGES
-				GRANT SELECT, INSERT, UPDATE, DELETE
-			 	ON TABLES
+            GRANT SELECT, INSERT, UPDATE, DELETE
+				ON ALL TABLES
 				IN SCHEMA public
-				TO %I '
+				TO %I ;'
+			, current_setting('myvars.postgres_db_user', true)::text 
+	);
+	EXECUTE format( '
+			ALTER DEFAULT PRIVILEGES			
+				IN SCHEMA public
+				GRANT SELECT, INSERT, UPDATE, DELETE
+			 		ON TABLES
+					TO %I ;'
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
             GRANT SELECT, UPDATE
 				ON ALL SEQUENCES
 				IN SCHEMA public
-				TO %I '
+				TO %I ;'
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-			ALTER DEFAULT PRIVILEGES
-				GRANT SELECT, UPDATE
-			 	ON SEQUENCES
+			ALTER DEFAULT PRIVILEGES			
 				IN SCHEMA public
-				TO %I '
+				GRANT SELECT, UPDATE
+			 		ON SEQUENCES
+					TO %I ;'
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);	
    	EXECUTE format( '
 			GRANT EXECUTE
 				ON ALL FUNCTIONS
 				IN SCHEMA public
-				TO %I '
+				TO %I ;'
            , current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-			ALTER DEFAULT PRIVILEGES
-				GRANT EXECUTE
-			 	ON FUNCTIONS
+			ALTER DEFAULT PRIVILEGES			
 				IN SCHEMA public
-				TO %I '
+				GRANT EXECUTE
+			 		ON FUNCTIONS
+					TO %I ;'
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -17,13 +17,6 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN
 	RAISE NOTICE 'User "%" already exists, re-creating it', current_setting('myvars.postgres_db_user', true)::text;
 	EXECUTE format( '
-            GRANT CONNECT
-				ON DATABASE %I
-				TO %I ;'
-			, current_setting('myvars.postgres_db_name', true)::text 
-			, current_setting('myvars.postgres_db_user', true)::text 
-	);
-	EXECUTE format( '
             GRANT SELECT, INSERT, UPDATE, DELETE
 				ON ALL TABLES
 				IN SCHEMA public
@@ -36,6 +29,13 @@ EXCEPTION WHEN OTHERS THEN
 				GRANT SELECT, INSERT, UPDATE, DELETE
 			 		ON TABLES
 					TO %I ;'
+			, current_setting('myvars.postgres_db_user', true)::text 
+	);
+	EXECUTE format( '
+            GRANT CONNECT
+				ON DATABASE %I
+				TO %I ;'
+			, current_setting('myvars.postgres_db_name', true)::text 
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -1,6 +1,6 @@
--- src: https://stackoverflow.com/a/49175321/65706
--- src: https://dba.stackexchange.com/a/213921/1245
--- src: https://stackoverflow.com/a/22684537/65706
+-- \echo 'src: https://stackoverflow.com/a/49175321/65706'
+-- \echo 'src: https://dba.stackexchange.com/a/213921/1245'
+-- \echo 'src: https://stackoverflow.com/a/22684537/65706'
 
 SET myvars.postgres_db_user TO :'postgres_db_user';
 SET myvars.postgres_db_user_pw TO :'postgres_db_user_pw';
@@ -17,60 +17,69 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN
 	RAISE NOTICE 'User "%" already exists, re-creating it', current_setting('myvars.postgres_db_user', true)::text;
 	EXECUTE format( '
-    		ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I '
+            GRANT SELECT, INSERT, UPDATE, DELETE
+				ON ALL TABLES
+				IN SCHEMA public
+				TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I '
+			ALTER DEFAULT PRIVILEGES
+				GRANT SELECT, INSERT, UPDATE, DELETE
+			 	ON TABLES
+				IN SCHEMA public
+				TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-            GRANT SELECT ON ALL TABLES IN SCHEMA PUBLIC TO %I '
+            GRANT SELECT, UPDATE
+				ON ALL SEQUENCES
+				IN SCHEMA public
+				TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-            GRANT SELECT, INSERT, UPDATE, DELETE , REFERENCES ON ALL TABLES IN SCHEMA public TO %I '
+			ALTER DEFAULT PRIVILEGES
+				GRANT SELECT, UPDATE
+			 	ON SEQUENCES
+				IN SCHEMA public
+				TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
-	);
-
-	EXECUTE format( '
-            GRANT SELECT,INSERT,UPDATE,DELETE,TRUNCATE ON ALL TABLES IN SCHEMA public TO %I '
-			, current_setting('myvars.postgres_db_user', true)::text 
-	);
-	
+	);	
    	EXECUTE format( '
-           GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO %I '
+			GRANT EXECUTE
+				ON ALL FUNCTIONS
+				IN SCHEMA public
+				TO %I '
            , current_setting('myvars.postgres_db_user', true)::text 
 	);
-   
-   EXECUTE format( '
-           GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I '
-           , current_setting('myvars.postgres_db_user', true)::text 
-	);
-   EXECUTE format( '
-           ALTER DEFAULT PRIVILEGES FOR USER %I IN SCHEMA public GRANT SELECT ON TABLES TO %I '
-		   , current_setting('myvars.postgres_db_user', true)::text 
+	EXECUTE format( '
+			ALTER DEFAULT PRIVILEGES
+				GRANT EXECUTE
+			 	ON FUNCTIONS
+				IN SCHEMA public
+				TO %I '
+			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 
 END
 $do$;
 
 
--- \echo 'Enable this for newly created relations too, then set the default permissions:'
-ALTER DEFAULT PRIVILEGES IN SCHEMA public 
-   GRANT ALL PRIVILEGES ON TABLES TO :postgres_db_user;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public 
-   GRANT ALL PRIVILEGES ON SEQUENCES TO :postgres_db_user;
+-- \echo 'Uncomment to enable this for newly created relations, then set the default permissions:'
+-- \echo 'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+-- \echo '   GRANT ALL PRIVILEGES ON TABLES TO :postgres_db_user;'
+-- \echo 'ALTER DEFAULT PRIVILEGES IN SCHEMA public '
+-- \echo '   GRANT ALL PRIVILEGES ON SEQUENCES TO :postgres_db_user;'
 
-GRANT SELECT ON ALL TABLES IN SCHEMA PUBLIC TO :postgres_db_user;
-GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO :postgres_db_user;
-GRANT ALL PRIVILEGES ON DATABASE :postgres_db_name TO :postgres_db_user;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :postgres_db_user;
-GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;
+-- \echo 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO :postgres_db_user;'
+-- \echo 'GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO :postgres_db_user;'
+-- \echo 'GRANT ALL PRIVILEGES ON DATABASE :postgres_db_name TO :postgres_db_user;'
+-- \echo 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;''
+-- \echo 'GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :postgres_db_user;'
+-- \echo 'GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;'
 
 SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolconnlimit 
 	FROM pg_roles 
 	WHERE 1=1
 	AND rolname=:'postgres_db_user';
-

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -58,7 +58,7 @@ END
 $do$;
 
 
--- to enable this for newly created relations too, then set the default permissions:
+-- \echo 'Enable this for newly created relations too, then set the default permissions:'
 ALTER DEFAULT PRIVILEGES IN SCHEMA public 
    GRANT ALL PRIVILEGES ON TABLES TO :postgres_db_user;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public 
@@ -69,11 +69,10 @@ GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO :postgres_db_user;
 GRANT ALL PRIVILEGES ON DATABASE :postgres_db_name TO :postgres_db_user;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :postgres_db_user;
-GRANT SELECT, INSERT, UPDATE, DELETE , REFERENCES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ALL TABLES IN SCHEMA public TO :postgres_db_user;
 
 SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolconnlimit 
-FROM pg_roles 
-WHERE 1=1
-AND rolname=:'postgres_db_user'
-;
+	FROM pg_roles 
+	WHERE 1=1
+	AND rolname=:'postgres_db_user';
 

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -17,11 +17,11 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN
 	RAISE NOTICE 'User "%" already exists, re-creating it', current_setting('myvars.postgres_db_user', true)::text;
 	EXECUTE format( '
-         ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I;'
+    		ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
-            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I'
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO %I '
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	EXECUTE format( '
@@ -38,17 +38,18 @@ EXCEPTION WHEN OTHERS THEN
 			, current_setting('myvars.postgres_db_user', true)::text 
 	);
 	
-   EXECUTE format( '
+   	EXECUTE format( '
            GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO %I '
-         , current_setting('myvars.postgres_db_user', true)::text 
+           , current_setting('myvars.postgres_db_user', true)::text 
 	);
    
    EXECUTE format( '
-           GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I'
-         , current_setting('myvars.postgres_db_user', true)::text 
+           GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %I '
+           , current_setting('myvars.postgres_db_user', true)::text 
 	);
    EXECUTE format( '
-           ALTER DEFAULT PRIVILEGES FOR USER %I IN SCHEMA public GRANT SELECT ON TABLES TO %I, current_setting('myvars.postgres_db_user', true)::text 
+           ALTER DEFAULT PRIVILEGES FOR USER %I IN SCHEMA public GRANT SELECT ON TABLES TO %I '
+		   , current_setting('myvars.postgres_db_user', true)::text 
 	);
 
 ;  "

--- a/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/01.create-qto-app-user.pgsql
@@ -52,9 +52,6 @@ EXCEPTION WHEN OTHERS THEN
 		   , current_setting('myvars.postgres_db_user', true)::text 
 	);
 
-;  "
-
-
 END
 $do$;
 

--- a/src/sql/pgsql/qto/02.alter-qto-app-user.pgsql
+++ b/src/sql/pgsql/qto/02.alter-qto-app-user.pgsql
@@ -9,15 +9,37 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ALTER DEFAULT PRIVILEGES IN SCHEMA public 
    GRANT ALL PRIVILEGES ON SEQUENCES TO :"postgres_db_user";
 
-GRANT SELECT ON ALL TABLES IN SCHEMA PUBLIC TO :"postgres_db_user";
-GRANT SELECT ON ALL TABLES IN SCHEMA pg_catalog TO :"postgres_db_user";
-GRANT ALL PRIVILEGES ON DATABASE :"postgres_db_name" TO :"postgres_db_user";
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :"postgres_db_user";
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :"postgres_db_user";
-GRANT SELECT, INSERT, UPDATE, DELETE , REFERENCES ON ALL TABLES IN SCHEMA public TO :"postgres_db_user";
+GRANT SELECT
+	ON ALL TABLES
+	IN SCHEMA PUBLIC
+	TO :"postgres_db_user";
+	
+GRANT SELECT
+	ON ALL TABLES
+	IN SCHEMA pg_catalog
+	TO :"postgres_db_user";
 
-SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolconnlimit FROM pg_app_roles 
-WHERE 1=1
-AND rolname=:'postgres_db_user'
-;
+GRANT ALL PRIVILEGES
+	ON DATABASE :"postgres_db_name"
+	TO :"postgres_db_user";
+	
+GRANT ALL PRIVILEGES
+	ON ALL TABLES
+	IN SCHEMA public
+	TO :"postgres_db_user";
+	
+GRANT ALL PRIVILEGES
+	ON ALL SEQUENCES
+	IN SCHEMA public
+	TO :"postgres_db_user";
+	
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
+	ON ALL TABLES
+	IN SCHEMA public
+	TO :"postgres_db_user";
+
+SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolconnlimit
+	FROM pg_app_roles 
+	WHERE 1=1
+	ND rolname=:'postgres_db_user';
 

--- a/src/sql/pgsql/qto/03.create-function.fnc_set_update_time.sql
+++ b/src/sql/pgsql/qto/03.create-function.fnc_set_update_time.sql
@@ -1,10 +1,9 @@
 CREATE OR REPLACE FUNCTION "fnc_set_update_time" () RETURNS trigger AS '
-    BEGIN
-        NEW.update_time = DATE_TRUNC(''second'', NOW());
-        RETURN NEW;
-    END;'
+	BEGIN
+		NEW.update_time = DATE_TRUNC(''second'', NOW());
+		RETURN NEW;
+	END;'
 LANGUAGE "plpgsql";
 
-select 'fnc_set_update_time exists is ' || exists(select * from pg_proc where proname = 'fnc_set_update_time')
-;
+SELECT 'fnc_set_update_time exists is ' || exists(SELECT * FROM pg_proc WHERE proname='fnc_set_update_time');
 

--- a/src/sql/pgsql/qto/app-itms/001.create-table.app_users.sql
+++ b/src/sql/pgsql/qto/app-itms/001.create-table.app_users.sql
@@ -1,19 +1,20 @@
 -- file: src/sql/pgsql/qto/app-itms/001.create-table.app_users.sql
 -- v0.8.4
 
-SELECT 'create the "app_users" table'
-; 
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_users'
+
+-- \echo '1. Creating the app_users table'
 
 CREATE TABLE public.app_users (
-    guid uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    guid UUID DEFAULT public.gen_random_uuid() NOT NULL,
     id bigint DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYMMDDHH12MISS'::text))::bigint NOT NULL,
-    name character varying(100) DEFAULT 'name...'::character varying NOT NULL,
+    name character varying(100) DEFAULT 'User name'::character varying NOT NULL,
     first_name character varying(50),
     last_name character varying(50),
-    email character varying(200) DEFAULT 'email...'::character varying NOT NULL,
+    email character varying(200) DEFAULT 'Email'::character varying NOT NULL,
     status smallint DEFAULT 1 NOT NULL,
-    description character varying(200) DEFAULT 'description...'::character varying,
-    password character varying(200) DEFAULT 'password...'::character varying NOT NULL,
+    description character varying(200) DEFAULT ''::character varying,
+    password character varying(200) DEFAULT 'Password'::character varying NOT NULL,
     update_time timestamp without time zone DEFAULT date_trunc('second'::text, now()),
     CONSTRAINT pk_app_users_guid PRIMARY KEY (guid)
 );
@@ -25,28 +26,28 @@ CREATE TABLE public.app_users (
 -- Dependencies: 281
 
 COPY public.app_users (guid, id, name, first_name, last_name, email, status, description, password, update_time) FROM stdin;
-2660a6e9-9e6b-4faa-8264-27a92872657b	190707231513	tau	anonymous	 user	test.anonymous.user@gmail.com	1	the test user	{CRYPT}$2a$08$iAmq3xMI4452eOmbexOXFOzccG7/kDVri21RZIainW2kYXq57xbdG	2020-05-01 21:06:10
-2660a6e9-9e6b-4faa-8264-27a92872657c	200107231510	trd	test reader	user	test.reader.user@gmail.com	1	the test user	{CRYPT}$2a$08$/Z3BoSd2cOO1Enb4xckj9Ocl/8dWGzUxlyaI0fDLveDSEPHQh6XiG	2020-05-01 21:06:10
-2660a6e9-9e6b-4faa-8264-27a92872657d	200107231511	ted	test editor	user	test.editor.user@gmail.com	1	the test user	{CRYPT}$2a$08$cbAMAMtbNJthEfglhyj6buI4GL13Yia4QTGIZXFE.9jhuVWZ1p/Ru	2020-05-01 21:06:10
-9426c566-0abd-4028-830f-82ed9f91d262	200502001502	pio	product instance	owner user	pio@gmail.com	1	description...	{CRYPT}$2a$08$nTM2/kqvQkNS.vuGV.0bG.h67j8Ci1DreZ16KeVPA8N9SwBohv5cm	2020-05-01 21:15:41
+2660a6e9-9e6b-4faa-8264-27a92872657b	190707231513	tau	anonymous	 user	test.anonymous.user@gmail.com	1	Test anonymous	{CRYPT}$2a$08$iAmq3xMI4452eOmbexOXFOzccG7/kDVri21RZIainW2kYXq57xbdG	2020-05-01 21:06:10
+2660a6e9-9e6b-4faa-8264-27a92872657c	200107231510	trd	test reader	user	test.reader.user@gmail.com	1	Test reader	{CRYPT}$2a$08$/Z3BoSd2cOO1Enb4xckj9Ocl/8dWGzUxlyaI0fDLveDSEPHQh6XiG	2020-05-01 21:06:10
+2660a6e9-9e6b-4faa-8264-27a92872657d	200107231511	ted	test editor	user	test.editor.user@gmail.com	1	Test editor	{CRYPT}$2a$08$cbAMAMtbNJthEfglhyj6buI4GL13Yia4QTGIZXFE.9jhuVWZ1p/Ru	2020-05-01 21:06:10
+9426c566-0abd-4028-830f-82ed9f91d262	200502001502	pio	product instance	owner user	pio@gmail.com	1	Test product instance owner	{CRYPT}$2a$08$nTM2/kqvQkNS.vuGV.0bG.h67j8Ci1DreZ16KeVPA8N9SwBohv5cm	2020-05-01 21:15:41
 \.
+                               
+-- \echo 'List columns of the created table app_users'
 
-   SELECT attrelid::regclass, attnum, attname
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_users'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_users'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
-   CREATE TRIGGER trg_set_update_time_on_app_users BEFORE UPDATE ON app_users 
-      FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time()
-   ;
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_users
+	BEFORE UPDATE ON app_users 
+    FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-   select tgname
-   from pg_trigger
-   where not tgisinternal
-   and tgrelid = 'app_users'::regclass
-   ;
-
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_users'::regclass;
 

--- a/src/sql/pgsql/qto/app-itms/002.create-table.app_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/002.create-table.app_roles.sql
@@ -1,66 +1,47 @@
 -- file: src/sql/pgsql/qto/app-itms/002.create-table.app_roles.sql
--- v0.8.3
+-- v0.8.4
 
--- DROP TABLE IF EXISTS app_roles ; 
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_roles;'
 
-SELECT 'create the "app_roles" table'
-; 
-   CREATE TABLE app_roles (
+-- \echo '1. Creating the app_roles table'
+
+CREATE TABLE app_roles (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
-    , name           varchar (100) NOT NULL DEFAULT 'name...'
-    , level          smallint NOT NULL DEFAULT 1000 -- the anonymous role
-    , description    varchar (200) NULL DEFAULT 'description...'
+    , name           varchar (100) NOT NULL DEFAULT 'Role name'
+    , level          smallint NOT NULL DEFAULT 1000
+    , description    varchar (200) NULL DEFAULT ''
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_roles_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-create unique index idx_app_roles_uniq_id on app_roles (id);
+CREATE unique index idx_app_roles_uniq_id
+	ON app_roles (id);
 
 
 INSERT INTO app_roles 
-   ( guid , id , name , level , description )
+   ( guid, id, name, access_level, description )
 VALUES
-   ( '71eea083-d818-4557-89fe-29eb950881aa' , '0' , 'PRODUCT_INSTANCE_OWNER', 0 , 'the product instance owner')
-; 
-INSERT INTO app_roles 
-   ( guid , id , name , level , description )
-VALUES
-   ( '71eea083-d818-4557-89fe-29eb950881ab' , '1' , 'ANONYMOUS', 1000 , 'Any non-registered user having access to the instance')
-; 
-INSERT INTO app_roles 
-   ( guid , id , name , level , description )
-VALUES
-   ( '71eea083-d818-4557-89fe-29eb950881ad' , '2' , 'READER', 7 , 'Has the right to read content')
-; 
-INSERT INTO app_roles 
-   ( guid , id , name , level , description )
-VALUES
-   ( '71eea083-d818-4557-89fe-29eb950881ac' , '3' , 'EDITOR', 2 , 'Has generally the right to edit content')
-; 
+   ('71eea083-d818-4557-89fe-29eb950881aa', 1, 'PRODUCT_INSTANCE_OWNER', 0, 'Product instance owner'),
+   ('71eea083-d818-4557-89fe-29eb950881ac', 2, 'EDITOR', 2, 'Has the right to edit content'),
+   ('71eea083-d818-4557-89fe-29eb950881ad', 3, 'READER', 7, 'Has the right to read content'),
+   ('71eea083-d818-4557-89fe-29eb950881ab', 4, 'ANONYMOUS', 1000, 'Non-registered user having access to instance');
 
 
-
-
-SELECT 'show the columns of the just created table'
-; 
-
-   SELECT attrelid::regclass, attnum, attname
+-- \echo 'List columns of the created table app_roles'
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_roles'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_roles'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum ; 
 
---The trigger:
-CREATE TRIGGER trg_set_update_time_on_app_roles BEFORE UPDATE ON app_roles 
-   FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_roles
+	BEFORE UPDATE ON app_roles 
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_roles'::regclass;
-
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_roles'::regclass;

--- a/src/sql/pgsql/qto/app-itms/002.create-table.app_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/002.create-table.app_roles.sql
@@ -20,7 +20,7 @@ CREATE unique index idx_app_roles_uniq_id
 
 
 INSERT INTO app_roles 
-   ( guid, id, name, access_level, description )
+   ( guid, id, name, level, description )
 VALUES
    ('71eea083-d818-4557-89fe-29eb950881aa', 1, 'PRODUCT_INSTANCE_OWNER', 0, 'Product instance owner'),
    ('71eea083-d818-4557-89fe-29eb950881ac', 2, 'EDITOR', 2, 'Has the right to edit content'),

--- a/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
@@ -11,8 +11,6 @@ CREATE TABLE app_user_roles (
     , description    varchar (200) NULL DEFAULT ''
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_user_roles_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
 CREATE UNIQUE INDEX idx_app_user_roles_uniq_id
@@ -27,16 +25,6 @@ ALTER TABLE public.app_user_roles
    REFERENCES app_users(guid) 
    ON DELETE CASCADE;
 ;
-
--- \echo 'If necessary, perform ALTER TABLE public.app_user_roles DROP CONSTRAINT fk_app_roles_noauth_guid;'
-
-ALTER TABLE public.app_user_roles 
-   ADD CONSTRAINT fk_app_users_guid 
-   FOREIGN KEY (app_users_guid)
-   REFERENCES app_users(guid) 
-   ON DELETE CASCADE;
-;
-
 
 -- \echo 'List columns of the created table app_user_roles');
 

--- a/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
@@ -1,63 +1,61 @@
-SELECT 'create the "app_user_roles" table'
-; 
-   CREATE TABLE app_user_roles (
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_user_roles;'
+
+-- \echo '2. Creating the app_user_roles table'
+
+CREATE TABLE app_user_roles (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
     , app_users_guid     UUID NOT NULL DEFAULT '2660a6e9-9e6b-4faa-8264-27a92872657b'
     , app_roles_guid     UUID NOT NULL DEFAULT '71eea083-d818-4557-89fe-29eb950881ab'
-    , name           varchar (100) NOT NULL DEFAULT 'name...'
-    , description    varchar (200) NULL DEFAULT 'description...'
+    , name           varchar (100) NOT NULL DEFAULT 'Role name'
+    , description    varchar (200) NULL DEFAULT ''
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_user_roles_guid PRIMARY KEY (guid)
     ) WITH (
       OIDS=FALSE
     );
 
-create unique index idx_app_user_roles_uniq_id on app_user_roles (id);
+CREATE UNIQUE INDEX idx_app_user_roles_uniq_id
+	ON app_user_roles (id);
 
 
-/*
-alter table public.app_user_roles 
-   drop constraint fk_app_users_guid 
-; 
-*/
-alter table public.app_user_roles 
-   add constraint fk_app_users_guid 
-   foreign key (app_users_guid)
-   references app_users(guid) 
-   on delete cascade
+-- \echo 'If necessary, perform ALTER TABLE public.app_user_roles DROP CONSTRAINT fk_app_users_guid;'
+
+ALTER TABLE public.app_user_roles
+   ADD CONSTRAINT fk_app_users_guid 
+   FOREIGN KEY (app_users_guid)
+   REFERENCES app_users(guid) 
+   ON DELETE CASCADE;
 ;
-/*
-alter table public.app_user_roles 
-   drop constraint fk_app_roles_guid 
-; 
-*/
-alter table public.app_user_roles 
-   add constraint fk_app_roles_guid 
-   foreign key (app_roles_guid)
-   references app_roles(guid) 
-   on delete cascade
+
+-- \echo 'If necessary, perform ALTER TABLE public.app_user_roles DROP CONSTRAINT fk_app_roles_noauth_guid;'
+
+ALTER TABLE public.app_user_roles 
+   ADD CONSTRAINT fk_app_users_guid 
+   FOREIGN KEY (app_users_guid)
+   REFERENCES app_users(guid) 
+   ON DELETE CASCADE;
 ;
 
 
-SELECT 'show the columns of the just created table'
-; 
+-- \echo 'List columns of the created table app_user_roles');
 
-   SELECT attrelid::regclass, attnum, attname
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_user_roles'::regclass
-   AND    attnum > 0
-   AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   WHERE  attrelid='public.app_user_roles'::regclass
+   AND    attnum>0
+   AND    NOT attisDROPped
+   ORDER  BY attnum; 
 
-CREATE TRIGGER trg_set_update_time_on_app_user_roles BEFORE UPDATE ON app_user_roles 
-   FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_user_roles
+	BEFORE UPDATE ON app_user_roles 
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_user_roles'::regclass;
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_user_roles'::regclass;
 
 --
 -- TOC entry 3355 (class 0 OID 137804)
@@ -66,8 +64,8 @@ and tgrelid = 'app_user_roles'::regclass;
 --
 
 COPY public.app_user_roles (guid, id, app_users_guid, app_roles_guid, name, description, update_time) FROM stdin;
-6f036963-52cc-4d49-ae36-984c75d14bb2	200411160810	2660a6e9-9e6b-4faa-8264-27a92872657c	71eea083-d818-4557-89fe-29eb950881ad	trd must be reader	description...	2020-05-01 21:13:48
-0fb84503-0d7a-4cdc-889b-4e4a8f6aac53	200410220814	2660a6e9-9e6b-4faa-8264-27a92872657d	71eea083-d818-4557-89fe-29eb950881ac	ted must be editor	description...	2020-05-01 21:14:01
-460cc595-7db7-4211-a271-d825b3801d1e	200224195828	2660a6e9-9e6b-4faa-8264-27a92872657b	71eea083-d818-4557-89fe-29eb950881ab	tau must be anonymous	description...	2020-05-01 21:14:11
-472cbd25-d8a5-4828-85f3-556387aea673	200502001551	9426c566-0abd-4028-830f-82ed9f91d262	71eea083-d818-4557-89fe-29eb950881aa	pio must be product instance owner	description...	2020-05-01 21:19:21
+6f036963-52cc-4d49-ae36-984c75d14bb2	200411160810	2660a6e9-9e6b-4faa-8264-27a92872657c	71eea083-d818-4557-89fe-29eb950881ad	trd must be reader	Test reader user has reader role	2020-05-01 21:13:48
+0fb84503-0d7a-4cdc-889b-4e4a8f6aac53	200410220814	2660a6e9-9e6b-4faa-8264-27a92872657d	71eea083-d818-4557-89fe-29eb950881ac	ted must be editor	Test editor user has editor role	2020-05-01 21:14:01
+460cc595-7db7-4211-a271-d825b3801d1e	200224195828	2660a6e9-9e6b-4faa-8264-27a92872657b	71eea083-d818-4557-89fe-29eb950881ab	tau must be anonymous	Test anonymous user has anonymous role	2020-05-01 21:14:11
+472cbd25-d8a5-4828-85f3-556387aea673	200502001551	9426c566-0abd-4028-830f-82ed9f91d262	71eea083-d818-4557-89fe-29eb950881aa	pio must be product instance owner	Test product instance owner has instance owner role	2020-05-01 21:19:21
 \.

--- a/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/003.create-table.app_user_roles.sql
@@ -25,6 +25,13 @@ ALTER TABLE public.app_user_roles
    REFERENCES app_users(guid) 
    ON DELETE CASCADE;
 ;
+	
+ALTER TABLE public.app_user_roles
+   ADD CONSTRAINT fk_app_roles_guid 
+   FOREIGN KEY (app_roles_guid)
+   REFERENCES app_roles(guid) 
+   ON DELETE CASCADE;
+;
 
 -- \echo 'List columns of the created table app_user_roles');
 

--- a/src/sql/pgsql/qto/app-itms/004.create-table.app_items.sql
+++ b/src/sql/pgsql/qto/app-itms/004.create-table.app_items.sql
@@ -1,42 +1,40 @@
--- DROP TABLE IF EXISTS app_items ; 
+-- v0.8.4
 
-SELECT 'create the "app_items" table'
-; 
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_items;'
+
+-- \echo '5. Creating the app_items table'
+
    CREATE TABLE app_items (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigserial UNIQUE 
-    , prio           integer NOT NULL DEFAULT 1
-    , name           varchar (200) NOT NULL DEFAULT 'name...'
-    , ver            varchar (10) NOT NULL DEFAULT 'version...'
-    , description    varchar (4000) DEFAULT 'description...'
+    , prio           smallint NOT NULL DEFAULT 1
+    , name           varchar (200) NOT NULL DEFAULT 'Item name'
+    , ver            varchar (10) NOT NULL DEFAULT '0.8.4'
+    , description    varchar (4000) DEFAULT ''
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_items_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-create unique index idx_uniq_app_items_id on app_items (id);
+CREATE UNIQUE INDEX idx_uniq_app_items_id
+	ON app_items (id);
 
-
-
-SELECT 'show the columns of the just created table'
-; 
-
-   SELECT attrelid::regclass, attnum, attname
+-- \echo 'List columns of the created table app_items'
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_items'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_items'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
---The trigger:
-CREATE TRIGGER trg_set_update_time_on_app_items BEFORE UPDATE ON app_items FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_items
+	BEFORE UPDATE ON app_items
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_items'::regclass;
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_items'::regclass;
 
 --
 -- TOC entry 3310 (class 0 OID 58960)

--- a/src/sql/pgsql/qto/app-itms/005.create-table.app_items_doc.sql
+++ b/src/sql/pgsql/qto/app-itms/005.create-table.app_items_doc.sql
@@ -1,8 +1,10 @@
--- DROP TABLE IF EXISTS app_items_doc CASCADE;
+-- v0.8.4
 
-SELECT 'create the "app_items_doc" table'
-; 
-   CREATE TABLE app_items_doc (
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_items_doc;'
+
+-- \echo '5. Creating the app_items_doc table'
+
+CREATE TABLE app_items_doc (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
     , level          integer NULL
@@ -14,18 +16,17 @@ SELECT 'create the "app_items_doc" table'
     , status         varchar (10) NOT NULL DEFAULT '02-todo'
     , description    varchar (4000)
     , item_id        integer NULL -- the future hook for the table name in the url
-    , prio           integer NOT NULL DEFAULT 1
+    , prio           smallint NOT NULL DEFAULT 1
     , src            varchar (4000)
     , formats        text NULL
     , lft            bigint  NULL
     , rgt            bigint  NULL
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_items_doc_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-   create unique index idx_uniq_app_items_doc_id on app_items_doc (id);
+CREATE unique index idx_uniq_app_items_doc_id
+	ON app_items_doc (id);
 
 -- insert into app_items_doc ( id , level , seq , lft , rgt , name) values ( 0 , 0, 1, 1, 8, 'ITEMS DOC' );
 -- insert into app_items_doc ( id , level , seq , lft , rgt , name) values ( 1 , 1, 2, 2, 3, 'lists' );
@@ -33,26 +34,23 @@ SELECT 'create the "app_items_doc" table'
 -- insert into app_items_doc ( id , level , seq , lft , rgt , name) values ( 3 , 1, 4, 6, 7, 'labels' );
 
 
-SELECT 'show the columns of the just created table'
-; 
-
-   SELECT attrelid::regclass, attnum, attname
+-- \echo 'List columns of the created table app_items'
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_items_doc'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_items_doc'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
---The trigger:
-   CREATE TRIGGER trg_set_update_time_on_app_items_doc 
-   BEFORE UPDATE ON app_items_doc 
-   FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_items_doc
+	BEFORE UPDATE ON app_items_doc
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_items_doc'::regclass;
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_items_doc'::regclass;
 
 --
 -- TOC entry 3321 (class 0 OID 46939)

--- a/src/sql/pgsql/qto/app-itms/006.create-table.app_routes.sql
+++ b/src/sql/pgsql/qto/app-itms/006.create-table.app_routes.sql
@@ -1,44 +1,40 @@
--- DROP TABLE IF EXISTS app_routes ; 
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_routes;'
 
-SELECT 'create the "app_routes" table'
-; 
-   CREATE TABLE app_routes (
+-- \echo '6. Creating the app_routes table'
+
+CREATE TABLE app_routes (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
-    , prio           integer NOT NULL DEFAULT 1
+    , prio           smallint NOT NULL DEFAULT 1
     , is_open        bool NOT NULL default true
     , has_subject    bool NOT NULL default true
     , is_backend     bool NOT NULL default true
-    , name           varchar (200) NOT NULL DEFAULT 'route-name...'
-    , description    varchar (4000) DEFAULT 'description...'
+    , name           varchar (200) NOT NULL DEFAULT 'Route name'
+    , description    varchar (4000) DEFAULT ''
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_routes_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-create unique index idx_uniq_app_routes_id on app_routes (id);
+CREATE UNIQUE INDEX idx_uniq_app_routes_id
+	ON app_routes (id);
 
-
-
-SELECT 'show the columns of the just created table'
-; 
-
-   SELECT attrelid::regclass, attnum, attname
+-- \echo 'List columns of the created table app_routes'
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_routes'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_routes'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
---The trigger:
-CREATE TRIGGER trg_set_update_time_on_app_routes BEFORE UPDATE ON app_routes FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_routes
+	BEFORE UPDATE ON app_routes
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_routes'::regclass;
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_routes'::regclass;
 
 
 --

--- a/src/sql/pgsql/qto/app-itms/007.create-table.app_items_roles_permissions.sql
+++ b/src/sql/pgsql/qto/app-itms/007.create-table.app_items_roles_permissions.sql
@@ -1,8 +1,11 @@
--- DROP TABLE IF EXISTS app_items_roles_permissions ; 
+-- file: src/sql/pgsql/qto/app-itms/003.create-table.app_items_roles_permissions.sql
+-- v0.8.4
 
-SELECT 'create the "app_items_roles_permissions" table'
-; 
-   CREATE TABLE app_items_roles_permissions (
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_items_roles_permissions;' 
+
+-- \echo '4. Creating the app_items_roles_permissions table'
+
+CREATE TABLE app_items_roles_permissions (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             BIGSERIAL UNIQUE NOT NULL 
     , app_roles_guid     UUID NOT NULL DEFAULT gen_random_uuid()

--- a/src/sql/pgsql/qto/app-itms/008.create-table.app_imgs.sql
+++ b/src/sql/pgsql/qto/app-itms/008.create-table.app_imgs.sql
@@ -1,44 +1,39 @@
--- DROP TABLE IF EXISTS app_imgs CASCADE;
+-- \echo 'If necessary, perform DROP TABLE IF EXISTS app_imgs CASCADE'
 
-SELECT 'create the "app_imgs" table'
-; 
-   CREATE TABLE app_imgs (
+-- \echo '8. Creating the app_imgs table'
+
+CREATE TABLE app_imgs (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
-    , name           varchar (200) NOT NULL DEFAULT 'image figure title ...'
+    , name           varchar (200) NOT NULL DEFAULT 'Image figure title'
     , relative_path  varchar (1000) NOT NULL DEFAULT 'src/perl/qto/public/dat/img/qto/...'
     , http_path      varchar (4000) NOT NULL DEFAULT 'https://raw.githubusercontent.com/YordanGeorgiev/qto/dev/doc/img/..'
     , style          varchar (100) NOT NULL DEFAULT 'width: 800px; height: 600x'
     , item_guid      UUID NOT NULL DEFAULT gen_random_uuid()
-    , description    varchar (4000) NOT NULL DEFAULT 'txt to appear on alt ...' 
+    , description    varchar (4000) NOT NULL DEFAULT 'Alt text' 
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_app_imgs_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-   create unique index idx_uniq_app_imgs_id on app_imgs (id);
 
+CREATE UNIQUE INDEX idx_uniq_app_imgs_id
+	ON app_imgs (id);
 
+-- \echo 'List columns of the created table app_imgs'
 
-SELECT 'show the columns of the just created table'
-; 
-
-   SELECT attrelid::regclass, attnum, attname
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.app_imgs'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.app_imgs'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
---The trigger:
-   CREATE TRIGGER trg_set_update_time_on_app_imgs 
-   BEFORE UPDATE ON app_imgs 
-   FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+-- \echo 'Update time on every EXECUTE trigger:'
+CREATE TRIGGER trg_set_update_time_on_app_imgs
+	BEFORE UPDATE ON app_imgs
+	FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
 
-select tgname
-from pg_trigger
-where not tgisinternal
-and tgrelid = 'app_imgs'::regclass;
-
+SELECT tgname
+	FROM pg_trigger
+	WHERE NOT tgisinternal
+	AND tgrelid='app_imgs'::regclass;

--- a/src/sql/pgsql/qto/app-itms/300.create-function.fnc_set_update_time.sql
+++ b/src/sql/pgsql/qto/app-itms/300.create-function.fnc_set_update_time.sql
@@ -1,10 +1,9 @@
 CREATE OR REPLACE FUNCTION "fnc_set_update_time" () RETURNS trigger AS '
-    BEGIN
-        NEW.update_time = DATE_TRUNC(''second'', NOW());
-        RETURN NEW;
-    END;'
+	BEGIN
+		NEW.update_time = DATE_TRUNC(''second'', NOW());
+		RETURN NEW;
+	END;'
 LANGUAGE "plpgsql";
 
-select 'fnc_set_update_time exists is ' || exists(select * from pg_proc where proname = 'fnc_set_update_time')
+SELECT 'fnc_set_update_time exists is ' || exists(SELECT * FROM pg_proc WHERE proname='fnc_set_update_time')
 ;
-

--- a/src/sql/pgsql/qto/app-itms/301.create-function.fnc_concat_ws.sql
+++ b/src/sql/pgsql/qto/app-itms/301.create-function.fnc_concat_ws.sql
@@ -1,5 +1,4 @@
 CREATE OR REPLACE FUNCTION fnc_concat_ws(text, VARIADIC text[])
-  RETURNS text LANGUAGE sql IMMUTABLE AS 'SELECT array_to_string($2, $1)'
-  ;
+	RETURNS text LANGUAGE sql IMMUTABLE AS 'SELECT array_to_string($2, $1)';
 
-select 'fnc_concat_ws exists is ' || exists(select * from pg_proc where proname = 'fnc_concat_ws')
+SELECT 'fnc_concat_ws exists is ' || exists(SELECT * FROM pg_proc WHERE proname = 'fnc_concat_ws')

--- a/src/sql/pgsql/qto/app-itms/302.create-function.fnc_get_app_routes.sql
+++ b/src/sql/pgsql/qto/app-itms/302.create-function.fnc_get_app_routes.sql
@@ -1,24 +1,24 @@
 CREATE FUNCTION fnc_get_app_routes()
-  RETURNS TABLE (
-               id             bigint
-             , is_open        bool 
-             , is_backend     bool 
-             , has_subject    bool 
-             , name           varchar (200)
- ) AS 
+	RETURNS TABLE (
+			id				bigint
+			, is_open		bool 
+			, is_backend	bool 
+			, has_subject	bool 
+			, name			varchar (200)
+	) AS 
 $func$
 BEGIN
-   RETURN QUERY
-   SELECT 
+	RETURN QUERY
+	SELECT 
 		ROW_NUMBER () OVER (ORDER BY app_routes.name) as id
-      , app_routes.is_open as is_open
-      , app_routes.is_backend as is_backend
-      , app_routes.has_subject as has_subject
-      , app_routes.name as name
-   FROM app_routes
-   WHERE 1=1
+		, app_routes.is_open as is_open
+		, app_routes.is_backend as is_backend
+		, app_routes.has_subject as has_subject
+		, app_routes.name as name
+	FROM app_routes
+	WHERE 1=1
 ;
 END
 $func$  LANGUAGE plpgsql;
 
--- call by: psql -d dev_qto -c "select * from fnc_get_app_routes() "
+-- \echo 'call by: psql -d dev_qto -c "select * from fnc_get_app_routes() "'

--- a/src/sql/pgsql/qto/app-itms/303.create-function.fnc_get_function_args.sql
+++ b/src/sql/pgsql/qto/app-itms/303.create-function.fnc_get_function_args.sql
@@ -1,79 +1,79 @@
 CREATE FUNCTION fnc_get_function_args(
-  IN funcname character varying,
-  IN schema character varying,
-  OUT pos integer,
-  OUT direction character,
-  OUT argname character varying,
-  OUT datatype character varying)
+	IN funcname character varying,
+	IN schema character varying,
+	OUT pos integer,
+	OUT direction character,
+	OUT argname character varying,
+	OUT datatype character varying)
 RETURNS SETOF RECORD AS $$DECLARE
-  rettype character varying;
-  argtypes oidvector;
-  allargtypes oid[];
-  argmodes "char"[];
-  argnames text[];
-  mini integer;
-  maxi integer;
+	rettype character varying;
+	argtypes oidvector;
+	allargtypes oid[];
+	argmodes "char"[];
+	argnames text[];
+	mini integer;
+	maxi integer;
 BEGIN
-  /* get object ID of function */
-  SELECT INTO rettype, argtypes, allargtypes, argmodes, argnames
-         CASE
-         WHEN pg_proc.proretset
-         THEN 'setof ' || pg_catalog.format_type(pg_proc.prorettype, NULL)
-         ELSE pg_catalog.format_type(pg_proc.prorettype, NULL) END,
-         pg_proc.proargtypes,
-         pg_proc.proallargtypes,
-         pg_proc.proargmodes,
-         pg_proc.proargnames
-    FROM pg_catalog.pg_proc
-         JOIN pg_catalog.pg_namespace
-         ON (pg_proc.pronamespace = pg_namespace.oid)
-   WHERE pg_proc.prorettype <> 'pg_catalog.cstring'::pg_catalog.regtype
-     AND (pg_proc.proargtypes[0] IS NULL
-      OR pg_proc.proargtypes[0] <> 'pg_catalog.cstring'::pg_catalog.regtype)
-     -- AND NOT pg_proc.proisagg
-     AND pg_proc.proname = funcname
-     AND pg_namespace.nspname = schema
-     AND pg_catalog.pg_function_is_visible(pg_proc.oid);
-  
-  /* bail out if not found */
-  IF NOT FOUND THEN
-    RETURN;
-  END IF;
-  
-  /* return a row for the return value */
-  pos = 0;
-  direction = 'o'::char;
-  argname = 'RETURN VALUE';
-  datatype = rettype;
-  RETURN NEXT;
-  
-  /* unfortunately allargtypes is NULL if there are no OUT parameters */
-  IF allargtypes IS NULL THEN
-    mini = array_lower(argtypes, 1); maxi = array_upper(argtypes, 1);
-  ELSE
-    mini = array_lower(allargtypes, 1); maxi = array_upper(allargtypes, 1);
-  END IF;
-  IF maxi < mini THEN RETURN; END IF;
-  
-  /* loop all the arguments */
-  FOR i IN mini .. maxi LOOP
-    pos = i - mini + 1;
-    IF argnames IS NULL THEN
-      argname = NULL;
-    ELSE
-      argname = argnames[pos];
-    END IF;
-    IF allargtypes IS NULL THEN
-      direction = 'i'::char;
-      datatype = pg_catalog.format_type(argtypes[i], NULL);
-    ELSE
-      direction = argmodes[i];
-      datatype = pg_catalog.format_type(allargtypes[i], NULL);
-    END IF;
-    RETURN NEXT;
-  END LOOP;
-  
-  RETURN;
+	/* get object ID of function */
+	SELECT INTO rettype, argtypes, allargtypes, argmodes, argnames
+				 CASE
+				 WHEN pg_proc.proretset
+				 THEN 'setof ' || pg_catalog.format_type(pg_proc.prorettype, NULL)
+				 ELSE pg_catalog.format_type(pg_proc.prorettype, NULL) END,
+				 pg_proc.proargtypes,
+				 pg_proc.proallargtypes,
+				 pg_proc.proargmodes,
+				 pg_proc.proargnames
+		FROM pg_catalog.pg_proc
+				 JOIN pg_catalog.pg_namespace
+				 ON (pg_proc.pronamespace = pg_namespace.oid)
+	 WHERE pg_proc.prorettype <> 'pg_catalog.cstring'::pg_catalog.regtype
+		 AND (pg_proc.proargtypes[0] IS NULL
+			OR pg_proc.proargtypes[0] <> 'pg_catalog.cstring'::pg_catalog.regtype)
+		 -- AND NOT pg_proc.proisagg
+		 AND pg_proc.proname = funcname
+		 AND pg_namespace.nspname = schema
+		 AND pg_catalog.pg_function_is_visible(pg_proc.oid);
+	
+	/* bail out if not found */
+	IF NOT FOUND THEN
+		RETURN;
+	END IF;
+	
+	/* return a row for the return value */
+	pos = 0;
+	direction = 'o'::char;
+	argname = 'RETURN VALUE';
+	datatype = rettype;
+	RETURN NEXT;
+	
+	/* unfortunately allargtypes is NULL if there are no OUT parameters */
+	IF allargtypes IS NULL THEN
+		mini = array_lower(argtypes, 1); maxi = array_upper(argtypes, 1);
+	ELSE
+		mini = array_lower(allargtypes, 1); maxi = array_upper(allargtypes, 1);
+	END IF;
+	IF maxi < mini THEN RETURN; END IF;
+	
+	/* loop all the arguments */
+	FOR i IN mini .. maxi LOOP
+		pos = i - mini + 1;
+		IF argnames IS NULL THEN
+			argname = NULL;
+		ELSE
+			argname = argnames[pos];
+		END IF;
+		IF allargtypes IS NULL THEN
+			direction = 'i'::char;
+			datatype = pg_catalog.format_type(argtypes[i], NULL);
+		ELSE
+			direction = argmodes[i];
+			datatype = pg_catalog.format_type(allargtypes[i], NULL);
+		END IF;
+		RETURN NEXT;
+	END LOOP;
+	
+	RETURN;
 END;$$ LANGUAGE plpgsql STABLE STRICT SECURITY INVOKER;
 
 COMMENT ON FUNCTION fnc_get_function_args(character varying, character
@@ -86,4 +86,4 @@ argument the following data:
 - data type$$;
 
 -- src: https://www.alberton.info/postgresql_meta_info.html
--- call by: psql -d dev_qto -c "SELECT * FROM  fnc_get_function_args('fnc_get_all_users_app_roles','public') "
+-- call by: psql -d dev_qto -c "SELECT * FROM	fnc_get_function_args('fnc_get_all_users_app_roles','public') "

--- a/src/sql/pgsql/qto/app-itms/304.create-function.fnc_get_all_app_user_roles.sql
+++ b/src/sql/pgsql/qto/app-itms/304.create-function.fnc_get_all_app_user_roles.sql
@@ -1,32 +1,30 @@
-
-
 CREATE FUNCTION fnc_get_all_app_user_roles()
-  RETURNS TABLE (
-                 id           bigint
-               , user_id     bigint
-               , email        varchar(200)
-               , user_name    varchar(200)
-               , user_status  smallint
-               , app_role    varchar(100)
-               , description  varchar(200)
+	RETURNS TABLE (
+							id					 bigint
+							 , user_id		 bigint
+							 , email				varchar(200)
+							 , user_name		varchar(200)
+							 , user_status	smallint
+							 , app_role		varchar(100)
+							 , description	varchar(200)
  ) AS 
 $func$
 BEGIN
-   RETURN QUERY
-   SELECT 
+	 RETURN QUERY
+	 SELECT 
 		ROW_NUMBER () OVER (ORDER BY app_users.id) as id
 		, app_users.id as user_id
 		, app_users.email as email
 		, app_users.name as user_name 
-      , app_users.status as user_status
+			, app_users.status as user_status
 		, app_roles.name as app_role
 		, app_user_roles.description as description
-   FROM app_user_roles
-   LEFT JOIN app_roles ON (app_roles.guid = app_user_roles.guid)
-   LEFT JOIN app_users ON (app_users.guid = app_user_roles.guid)
-   WHERE 1=1
+	 FROM app_user_roles
+	 LEFT JOIN app_roles ON (app_roles.guid = app_user_roles.guid)
+	 LEFT JOIN app_users ON (app_users.guid = app_user_roles.guid)
+	 WHERE 1=1
 ;
 END
-$func$  LANGUAGE plpgsql;
+$func$	LANGUAGE plpgsql;
 
--- call by: psql -d dev_qto -c "select * from fnc_get_all_app_user_roles() "
+-- \echo 'call by: psql -d dev_qto -c "select * from fnc_get_all_app_user_roles() "'

--- a/src/sql/pgsql/qto/app-itms/305.create-function.fnc_get_app_items_roles_permissions.sql
+++ b/src/sql/pgsql/qto/app-itms/305.create-function.fnc_get_app_items_roles_permissions.sql
@@ -5,31 +5,31 @@
 -- psql -d dev_qto -c "select * from fnc_get_app_items_roles_permissions() "
 
 CREATE FUNCTION fnc_get_app_items_roles_permissions()
-  RETURNS TABLE (
-                 id                 bigint
-               , app_roles_name         varchar(200)
-               , table_name         varchar(200)
-               , route_name         varchar(200)
-               , name               varchar(200)
+	RETURNS TABLE (
+							id								 bigint
+							 , app_roles_name				 varchar(200)
+							 , table_name				 varchar(200)
+							 , route_name				 varchar(200)
+							 , name							 varchar(200)
  ) AS 
 $func$
 BEGIN
-   RETURN QUERY
-   SELECT 
+	 RETURN QUERY
+	 SELECT 
 		ROW_NUMBER () OVER (ORDER BY app_roles.guid) as id
-      , app_roles.name   as app_roles_name
-      , t2.name      as table_name
-      , t3.name      as route_name
-		, cast(app_roles.name || '__' || t3.name || '__ON__' || t2.name as varchar(200))  as name
-   from app_roles
-   cross join (
-      SELECT app_items.guid , app_items.name 
-         FROM app_items
-         WHERE 1=1 and app_items.name not like 'test_%'
-         ) t2
-   cross join (
-      SELECT app_routes.guid , app_routes.name FROM app_routes) t3
-   
+			, app_roles.name	 as app_roles_name
+			, t2.name			as table_name
+			, t3.name			as route_name
+		, cast(app_roles.name || '__' || t3.name || '__ON__' || t2.name as varchar(200))	AS name
+	 FROM app_roles
+	 CROSS JOIN (
+			SELECT app_items.guid , app_items.name 
+				 FROM app_items
+				 WHERE 1=1 and app_items.name NOT LIKE 'test_%'
+				 ) t2
+	 CROSS JOIN (
+			SELECT app_routes.guid , app_routes.name FROM app_routes) t3
+	 
 ;
 END
-$func$  LANGUAGE plpgsql;
+$func$	LANGUAGE plpgsql;

--- a/src/sql/pgsql/qto/tables/04.create-table-yearly_issues.sql
+++ b/src/sql/pgsql/qto/tables/04.create-table-yearly_issues.sql
@@ -1,8 +1,8 @@
- ---- DROP TABLE IF EXISTS yearly_issues ; 
+-- \echo 'DROP TABLE IF EXISTS yearly_issues ;'
 
-SELECT 'create the "yearly_issues" table'
-; 
-   CREATE TABLE yearly_issues (
+SELECT 'Creating the yearly_issues table'; 
+
+CREATE TABLE yearly_issues (
       guid           UUID NOT NULL DEFAULT gen_random_uuid()
     , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
     , type           varchar (30) NOT NULL DEFAULT 'task'
@@ -14,27 +14,27 @@ SELECT 'create the "yearly_issues" table'
     , owner          varchar (20) NOT NULL DEFAULT 'unknown'
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
     , CONSTRAINT pk_yearly_issues_guid PRIMARY KEY (guid)
-    ) WITH (
-      OIDS=FALSE
     );
 
-create unique index idx_uniq_yearly_issues_id on yearly_issues (id);
-
+CREATE unique index idx_uniq_yearly_issues_id
+	ON yearly_issues (id);
 
 
 SELECT 'show the columns of the just created table'
 ; 
 
-   SELECT attrelid::regclass, attnum, attname
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
-   WHERE  attrelid = 'public.yearly_issues'::regclass
-   AND    attnum > 0
+   WHERE  attrelid='public.yearly_issues'::regclass
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
 --The trigger:
-CREATE TRIGGER trg_set_update_time_on_yearly_issues BEFORE UPDATE ON yearly_issues FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+CREATE TRIGGER trg_set_update_time_on_yearly_issues
+	BEFORE UPDATE ON yearly_issues
+	FOR EACH ROW
+	EXECUTE PROCEDURE fnc_set_update_time();
 
 select tgname
 from pg_trigger

--- a/src/sql/pgsql/qto/tables/2020/2020-01/create-table-yearly_issues_2020.sql
+++ b/src/sql/pgsql/qto/tables/2020/2020-01/create-table-yearly_issues_2020.sql
@@ -13,7 +13,7 @@ CREATE TABLE yearly_issues_2020 (
     , description    varchar (4000)
     , owner          varchar (20) NOT NULL DEFAULT 'unknown'
     , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
-    , CONSTRAINT pk_yearly_issues_guid PRIMARY KEY (guid)
+    , CONSTRAINT pk_yearly_issues_2020_guid PRIMARY KEY (guid)
     );
 
 CREATE unique index idx_uniq_yearly_issues_2020_id
@@ -25,11 +25,11 @@ SELECT 'show the columns of the just created table'
 ; 
 
 SELECT attrelid::regclass, attnum, attname
-   FROM   pg_attribute
-   WHERE  attrelid = 'public.yearly_issues_2020'::regclass
-   AND    attnum>0
-   AND    NOT attisdropped
-   ORDER  BY attnum; 
+	FROM   pg_attribute
+	WHERE  attrelid = 'public.yearly_issues_2020'::regclass
+	AND    attnum>0
+	AND    NOT attisdropped
+	ORDER  BY attnum; 
 
 --The trigger:
 CREATE TRIGGER trg_set_update_time_on_yearly_issues_2020

--- a/src/sql/pgsql/qto/tables/2020/2020-01/create-table-yearly_issues_2020.sql
+++ b/src/sql/pgsql/qto/tables/2020/2020-01/create-table-yearly_issues_2020.sql
@@ -1,39 +1,41 @@
--- DROP TABLE IF EXISTS yearly_issues_2020 ; 
+-- \echo 'DROP TABLE IF EXISTS yearly_issues_2020 ;'
 
-SELECT 'create the "yearly_issues_2020" table'
+SELECT 'create the yearly_issues_2020 table'
 ; 
-CREATE TABLE public.yearly_issues_2020 (
-    guid uuid DEFAULT public.gen_random_uuid() NOT NULL,
-    id bigint DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYMMDDHH12MISS'::text))::bigint NOT NULL,
-    category_guid uuid DEFAULT '70724562-d83c-446e-94cf-58ced84f3a0e'::uuid NOT NULL,
-    issues_status_guid uuid DEFAULT 'cb989a14-d0b8-46e4-b2cc-5e2a974b5d29'::uuid NOT NULL,
-    prio integer DEFAULT 0 NOT NULL,
-    name character varying(100) DEFAULT 'name ...'::character varying NOT NULL,
-    description character varying(4000),
-    app_users_guid uuid DEFAULT public.gen_random_uuid(),
-    type character varying(30) DEFAULT 'task'::character varying NOT NULL,
-    update_time timestamp without time zone DEFAULT date_trunc('second'::text, now())
-);
+CREATE TABLE yearly_issues_2020 (
+      guid           UUID NOT NULL DEFAULT gen_random_uuid()
+    , id             bigint UNIQUE NOT NULL DEFAULT cast (to_char(current_timestamp, 'YYMMDDHH12MISS') as bigint) 
+    , type           varchar (30) NOT NULL DEFAULT 'task'
+    , category       varchar (30) NOT NULL DEFAULT 'category ...'
+    , status         varchar (20) NOT NULL DEFAULT 'status ...'
+    , prio           integer NOT NULL DEFAULT 0
+    , name           varchar (100) NOT NULL DEFAULT 'name ...'
+    , description    varchar (4000)
+    , owner          varchar (20) NOT NULL DEFAULT 'unknown'
+    , update_time    timestamp DEFAULT DATE_TRUNC('second', NOW())
+    , CONSTRAINT pk_yearly_issues_guid PRIMARY KEY (guid)
+    );
 
-create unique index idx_uniq_yearly_issues_2020_id on yearly_issues_2020 (id);
+CREATE unique index idx_uniq_yearly_issues_2020_id
+	ON yearly_issues_2020 (id);
 
 
 
 SELECT 'show the columns of the just created table'
 ; 
 
-   SELECT attrelid::regclass, attnum, attname
+SELECT attrelid::regclass, attnum, attname
    FROM   pg_attribute
    WHERE  attrelid = 'public.yearly_issues_2020'::regclass
-   AND    attnum > 0
+   AND    attnum>0
    AND    NOT attisdropped
-   ORDER  BY attnum
-   ; 
+   ORDER  BY attnum; 
 
 --The trigger:
-CREATE TRIGGER trg_set_update_time_on_yearly_issues_2020 
-   BEFORE UPDATE ON yearly_issues_2020 
-   FOR EACH ROW EXECUTE PROCEDURE fnc_set_update_time();
+CREATE TRIGGER trg_set_update_time_on_yearly_issues_2020
+	BEFORE UPDATE ON yearly_issues_2020
+	FOR EACH ROW
+	EXECUTE PROCEDURE fnc_set_update_time();
 
 select tgname
 from pg_trigger


### PR DESCRIPTION
1. made DB creation scripts from opt/qto/src/sql/pgsql/qto/ more standard
2. limited qto-app-user rights
3. removed duplicate lines from Perl requirements modules, deleted Excel:Writer module - it was the slowest to install
4. removed "systemctl status redis" status showing up during deployment - it stopped installation and required user interaction
5. ssh-keygen generation now happens without hitting Enter
6. changed IPs in cnf/env files from 127.0.0.1 to 172.31.0.1, so it would be clear that these need to be replaced with local IPs
7. fixed properly commenting out "bind 127.0.0.1" in redis.conf, so installation will not break because of this anymore